### PR TITLE
use gh context for header writer path

### DIFF
--- a/.github/workflows/FE_headerWriter.yml
+++ b/.github/workflows/FE_headerWriter.yml
@@ -1,11 +1,6 @@
 on:
   workflow_call:
     inputs:
-      project_path:
-        description: 'root path of the project where files are stored'
-        required: true
-        type: string
-        default: '/home/runner/work/demosplan-core/demosplan-core'
       ignore_path:
         description: 'path to directories and files that schould be ignored'
         type: string
@@ -44,7 +39,7 @@ jobs:
 
       - name: Run headerWriter
         run: |
-          python3 .github/headerWriter.py -p ${{ inputs.project_path }} -i  ${{ inputs.ignore_path }} -a -v
+          python3 .github/headerWriter.py -p  ${{ github.workspace }} -i  ${{ inputs.ignore_path }} -a -v
         shell: bash
 
       - name: delete headerWriter


### PR DESCRIPTION
by using context information of the run we can avoid providing workspace path for the FE_headerwriter script and can keep trigger action identical for most of our repos