### PR TITLE
ci(refs T31847): use new checkout action

### DIFF
--- a/.github/workflows/ado_sync.yml
+++ b/.github/workflows/ado_sync.yml
@@ -17,8 +17,9 @@ jobs:
   push_to_ado:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
       - name: Push to ADO
         run: |
           git remote add ADO $ADO_REPO_URL


### PR DESCRIPTION
this PR could fix 
```
 ! [rejected]        main -> main (fetch first)
error: failed to push some refs to '***'
hint: Updates were rejected because the remote contains work that you do
hint: not have locally. This is usually caused by another repository pushing
hint: to the same ref. You may want to first integrate the remote changes
hint: (e.g., 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
```
error 