### PR TITLE
ci(refs T31847): fetch remote before pushing

### DIFF
--- a/.github/workflows/ado_sync.yml
+++ b/.github/workflows/ado_sync.yml
@@ -23,4 +23,5 @@ jobs:
       - name: Push to ADO
         run: |
           git remote add ADO $ADO_REPO_URL
+          git -c http.extraheader="Authorization: Basic $ADO_TOKEN" fetch ADO main
           git -c http.extraheader="Authorization: Basic $ADO_TOKEN" push ADO main


### PR DESCRIPTION
trying to prevent 
```
 ! [rejected]        main -> main (fetch first)
error: failed to push some refs to '***'
hint: Updates were rejected because the remote contains work that you do
hint: not have locally. This is usually caused by another repository pushing
hint: to the same ref. You may want to first integrate the remote changes
hint: (e.g., 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
```
error 