### PR TITLE
Ignore var comments

### DIFF
--- a/.github/php-cs-fixer/.php-cs-fixer-header.php
+++ b/.github/php-cs-fixer/.php-cs-fixer-header.php
@@ -31,6 +31,11 @@ $config
                 'comment_type' => 'PHPDoc',
                 'location'     => 'after_declare_strict',
             ],
+            'phpdoc_to_comment' => [
+                'ignored_tags'  => [
+                    'var',
+                ]
+            ],
         ]
     )
     ->setCacheFile('.php-cs-fixer-header.cache')


### PR DESCRIPTION
/** @var Type $type */ should not be converted to /* @var Type $type */ as it is needed by phpstan