### PR TITLE
chore: add reusable workflow for syncing tags to ADO

### DIFF
--- a/.github/workflows/ado_sync_ssh.yml
+++ b/.github/workflows/ado_sync_ssh.yml
@@ -22,7 +22,7 @@ jobs:
   push_to_ado:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0

--- a/.github/workflows/ado_sync_tag_ssh.yml
+++ b/.github/workflows/ado_sync_tag_ssh.yml
@@ -22,7 +22,7 @@ jobs:
   push_tag_to_ado:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ado_sync_tag_ssh.yml
+++ b/.github/workflows/ado_sync_tag_ssh.yml
@@ -1,0 +1,47 @@
+on:
+  workflow_call:
+    inputs:
+      ADO_REPO_URL:
+        description: 'Repository URL'
+        required: true
+        type: string
+      TAG_NAME:
+        description: 'Tag to push to ADO'
+        required: true
+        type: string
+    secrets:
+      ADO_TOKEN:
+        required: true
+
+env:
+  ADO_SSH_KEY: ${{ secrets.ADO_TOKEN }}
+  ADO_REPO_URL: ${{ inputs.ADO_REPO_URL }}
+  TAG_NAME: ${{ inputs.TAG_NAME }}
+
+jobs:
+  push_tag_to_ado:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup SSH key and known_hosts
+        run: |
+          mkdir -p /home/runner/ssh_ado
+          echo "$ADO_SSH_KEY" | base64 --decode > /home/runner/ssh_ado/id_rsa_ado
+          chmod 700 /home/runner/ssh_ado/id_rsa_ado
+          ssh-keyscan -t rsa www.dev.diplanung.de > /home/runner/ssh_ado/known_hosts
+
+      - name: Configure Git SSH command
+        run: |
+          git config core.sshCommand "ssh -i /home/runner/ssh_ado/id_rsa_ado -o UserKnownHostsFile=/home/runner/ssh_ado/known_hosts -o StrictHostKeyChecking=no"
+
+      - name: Push tag to ADO
+        run: |
+          git remote add ADO $ADO_REPO_URL
+          git push ADO refs/tags/$TAG_NAME
+
+      - name: Delete ssh key
+        run: |
+          rm -rf /home/runner/ssh_ado/id_rsa_ado


### PR DESCRIPTION
 - Adds ado_sync_tag_ssh.yml, a reusable workflow that pushes a git tag to an ADO repository via SSH                                                                  
 - Kept separate from the branch sync workflow so each has a single, clear responsibility